### PR TITLE
Fix crash when don't set up a remote repository

### DIFF
--- a/lib/src/git.dart
+++ b/lib/src/git.dart
@@ -27,6 +27,7 @@ Future<String> gitUserEmail() => gitConfig('user.email');
 Future<String> gitRepoHomepage() => gitConfig('remote.origin.url').then(repoUrlToHomepage);
 
 String repoUrlToHomepage(String repo) {
+  if (repo == '') return null;
   var uri = Uri.parse(repo);
   p.Context context = p.Style.url.context;
   // Remove '.git' suffix.


### PR DESCRIPTION
I'm not able to run `den spec` when I don't set up a remote repository.

```
$ mkdir test
$ git init
$ den spec
Unhandled exception:
Error on line 4, column 16 of c:%5CUsers%5CNobuhiro%5CDocuments%5CDevelop%5CDartlang%5Cdens%5Ctest_product%5Cpubspec.yaml: Mapping values are not allowed here. Did you miss a colon earlier?
homepage: https:
               ^
#0      Scanner._fetchValue (package:yaml/src/scanner.dart:719:9)
#1      Scanner._fetchNextToken (package:yaml/src/scanner.dart:454:11)
#2      Scanner._fetchMoreTokens (package:yaml/src/scanner.dart:336:7)
#3      Scanner.peek (package:yaml/src/scanner.dart:317:27)
#4      Parser._parseBlockMappingKey (package:yaml/src/parser.dart:421:26)
#5      Parser._stateMachine (package:yaml/src/parser.dart:86:16)
#6      Parser.parse (package:yaml/src/parser.dart:47:19)
#7      Loader._loadMapping (package:yaml/src/loader.dart:160:23)
#8      Loader._loadNode (package:yaml/src/loader.dart:82:44)
#9      Loader._loadDocument (package:yaml/src/loader.dart:62:20)
#10     Loader.load (package:yaml/src/loader.dart:54:20)
#11     loadYamlDocument (package:yaml/yaml.dart:51:25)
#12     loadYamlNode (package:yaml/yaml.dart:42:5)
#13     Pubspec.contents= (package:den_api/src/pubspec.dart:26:16)
#14     Pubspec._setValue (package:den_api/src/pubspec.dart:62:7)
#15     Pubspec.homepage= (package:den_api/src/pubspec.dart:50:29)
#16     Pubspec.init.<anonymous closure>.<anonymous closure>.dummyHomepage (package:den_api/src/pubspec.dart:153:17)
#17     Pubspec.init.<anonymous closure>.<anonymous closure>.<anonymous closure>.<anonymous closure> (package:den_api/src/pubspec.dart:164:26)
#18     _RootZone.runUnary (dart:async/zone.dart:1149)
#19     _Future._propagateToListeners.handleError (dart:async/future_impl.dart:533)
#20     _Future._propagateToListeners (dart:async/future_impl.dart:588)
#21     _Future._completeWithValue (dart:async/future_impl.dart:376)
#22     Future.wait.<anonymous closure> (dart:async/future.dart:299)
#23     _RootZone.runUnary (dart:async/zone.dart:1149)
#24     _Future._propagateToListeners.handleValueCallback (dart:async/future_impl.dart:502)
#25     _Future._propagateToListeners (dart:async/future_impl.dart:585)
#26     _Future._completeWithValue (dart:async/future_impl.dart:376)
#27     _Future._asyncComplete.<anonymous closure> (dart:async/future_impl.dart:430)
#28     _microtaskLoop (dart:async/schedule_microtask.dart:43)
#29     _microtaskLoopEntry (dart:async/schedule_microtask.dart:52)
#30     _runPendingImmediateCallback (dart:isolate-patch/isolate_patch.dart:96)
#31     _RawReceivePortImpl._handleMessage (dart:isolate-patch/isolate_patch.dart:151)
```

It fix this.
